### PR TITLE
Changes Event model to match database table

### DIFF
--- a/upe_calendar/models.py
+++ b/upe_calendar/models.py
@@ -3,8 +3,10 @@ from django.db import models
 class Event(models.Model):
     name = models.CharField(max_length=100)
     start_time = models.DateTimeField()
+    end_time = models.DateTimeField()
     description = models.TextField(max_length=10000, blank=True, null=True)
     location = models.CharField(max_length=100)
-    banner = models.CharField(max_length=4096)
+    thumbnail = models.CharField(max_length=100)
+    banner = models.CharField(max_length=100)
     def __str__(self):
         return self.name


### PR DESCRIPTION
I noticed that the Event model was missing the `end_time` and `thumbnail` fields from the `upe_calendar_event` table in the database. Because of this, these fields were missing on the admin page to add a new event and an error would occur because they were missing when trying to add the new event to the database.

This adds the `end_time` and `thumbnail` fields and also changes the length limit on the `banner` field to match the limit in the database.